### PR TITLE
ModbusMasterTcpConnection: Prevents a possible unhandled nullreference exception on disposal of ModbusMasterTcpConnection 

### DIFF
--- a/NModbus4/Properties/AssemblyInfo.cs
+++ b/NModbus4/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 [assembly: Guid("95B2AE1E-E0DC-4306-8431-D81ED10A2D5D")]
 [assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyInformationalVersion("2.1.0")]
+[assembly: AssemblyInformationalVersion("2.1.0-dev")]
 
 #if !SIGNED
 [assembly: InternalsVisibleTo(@"Modbus.UnitTests")]

--- a/NModbus4/Properties/AssemblyInfo.cs
+++ b/NModbus4/Properties/AssemblyInfo.cs
@@ -14,7 +14,8 @@ using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(false)]
 [assembly: Guid("95B2AE1E-E0DC-4306-8431-D81ED10A2D5D")]
-[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.0")]
 
 #if !SIGNED
 [assembly: InternalsVisibleTo(@"Modbus.UnitTests")]

--- a/nuget/NModbus4.nuspec
+++ b/nuget/NModbus4.nuspec
@@ -7,12 +7,11 @@
     <authors>$author$</authors>
     <owners>$author$</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-    <projectUrl>https://github.com/Maxwe11/NModbus4</projectUrl>
+    <projectUrl>https://github.com/NModbus4/NModbus4</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
-- fixes issue #11
-- fixes issue #12
+https://github.com/NModbus4/NModbus4/releases
     </releaseNotes>
     <copyright>Copyright 2015</copyright>
     <tags>modbus nmodbus rtu ascii tcp udp serial master slave</tags>


### PR DESCRIPTION
Prevents a possible unhandled nullreference exception on disposal, this happens in some cases when the master is still sending or the sent data is still being handled during disposal.